### PR TITLE
Fix CI release builds for macOS (x86_64) and Windows

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Prepare build
         env:
           DASH_ELECTRUM_VERSION: ${{ steps.set_vars.outputs.pkg_ver }}
+          ARCHFLAGS: "-arch x86_64"
+          CFLAGS: "-arch x86_64 -I/usr/local/include"
+          LDFLAGS: "-arch x86_64 -L/usr/local/lib -liconv"
         run: |
           ./contrib/dash/actions/install-osx.sh
       - name: Build dmg

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -8,15 +8,15 @@ on:
         required: true
         type: string
       target_os:
-          description: 'Target OS for build'
-          required: true
-          type: choice
-          options:
-            - All
-            - Linux
-            - Windows
-            - macOS
-            - Android
+        description: 'Target OS for build'
+        required: true
+        type: choice
+        options:
+          - All
+          - Linux
+          - Windows
+          - macOS
+          - Android
       prerelease:
         description: "True to set 'Pre-Release' option"
         required: true
@@ -61,12 +61,12 @@ jobs:
     name: create release for macOS
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set outputs for pkg_ver
         id: set_vars
         run: |
           source ./contrib/dash/electrum_dash_version_env.sh
-          echo "pkg_ver=$(echo $DASH_ELECTRUM_VERSION)" >> $GITHUB_OUTPUT
+          echo "pkg_ver=${DASH_ELECTRUM_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Prepare build
         env:
           DASH_ELECTRUM_VERSION: ${{ steps.set_vars.outputs.pkg_ver }}
@@ -103,17 +103,17 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install gettext python3-virtualenv
+          sudo apt-get install -y gettext python3-virtualenv
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set outputs for pkg_ver, apk_ver, vercode, is_release
         id: set_vars
         run: |
           source ./contrib/dash/electrum_dash_version_env.sh
-          echo "pkg_ver=$(echo $DASH_ELECTRUM_VERSION)" >> $GITHUB_OUTPUT
-          echo "apk_ver=$(echo $DASH_ELECTRUM_APK_VERSION)" >> $GITHUB_OUTPUT
-          echo "vercode=$(echo $DASH_ELECTRUM_VERSION_CODE)" >> $GITHUB_OUTPUT
-          echo "is_release=$(echo $IS_RELEASE)" >> $GITHUB_OUTPUT
+          echo "pkg_ver=${DASH_ELECTRUM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "apk_ver=${DASH_ELECTRUM_APK_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "vercode=${DASH_ELECTRUM_VERSION_CODE}" >> "$GITHUB_OUTPUT"
+          echo "is_release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
       - name: Prepare build
         if: ${{ steps.set_vars.outputs.is_release || matrix.is_mainnet[0] == 'false' }}
         env:
@@ -149,12 +149,12 @@ jobs:
     name: create release for Linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set outputs for pkg_ver
         id: set_vars
         run: |
           source ./contrib/dash/electrum_dash_version_env.sh
-          echo "pkg_ver=$(echo $DASH_ELECTRUM_VERSION)" >> $GITHUB_OUTPUT
+          echo "pkg_ver=${DASH_ELECTRUM_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Prepare build
         env:
           DASH_ELECTRUM_VERSION: ${{ steps.set_vars.outputs.pkg_ver }}
@@ -197,12 +197,12 @@ jobs:
     name: create release for Windows
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set outputs for pkg_ver
         id: set_vars
         run: |
           source ./contrib/dash/electrum_dash_version_env.sh
-          echo "pkg_ver=$(echo $DASH_ELECTRUM_VERSION)" >> $GITHUB_OUTPUT
+          echo "pkg_ver=${DASH_ELECTRUM_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Prepare build
         env:
           DASH_ELECTRUM_VERSION: ${{ steps.set_vars.outputs.pkg_ver }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -56,7 +56,7 @@ jobs:
 
   build_osx:
     needs: create_release
-    runs-on: macos-12
+    runs-on: macos-15-intel
     if: ${{ inputs.target_os == 'All' || inputs.target_os == 'macOS' }}
     name: create release for macOS
     steps:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -56,7 +56,7 @@ jobs:
 
   build_osx:
     needs: create_release
-    runs-on: macos-13
+    runs-on: macos-15
     if: ${{ inputs.target_os == 'All' || inputs.target_os == 'macOS' }}
     name: create release for macOS
     steps:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -56,7 +56,7 @@ jobs:
 
   build_osx:
     needs: create_release
-    runs-on: macos-15
+    runs-on: macos-12
     if: ${{ inputs.target_os == 'All' || inputs.target_os == 'macOS' }}
     name: create release for macOS
     steps:

--- a/contrib/build-wine/Dockerfile
+++ b/contrib/build-wine/Dockerfile
@@ -19,7 +19,7 @@ RUN dpkg --add-architecture i386 \
     && wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
     && wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -sc)/winehq-$(lsb_release -sc).sources \
     && apt-get update \
-    && apt-get install -y wine-stable=9.0.0.0~jammy-1 \
+    && apt-get install -y --install-recommends winehq-stable \
         cabextract xauth xvfb ca-certificates zip unzip p7zip-full  \
     && wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
     && chmod +x winetricks && mv winetricks /usr/local/bin \

--- a/contrib/dash/actions/script-osx.sh
+++ b/contrib/dash/actions/script-osx.sh
@@ -10,6 +10,10 @@ virtualenv -p python3.10 env
 source env/bin/activate
 PIP_CMD="pip"
 
+# Force compatibility for relic/bls with newer CMake
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+export CMAKE_ARGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
 $PIP_CMD install git+https://github.com/pshenmic/bls-signatures.git
 $PIP_CMD install --no-warn-script-location \
     -r contrib/deterministic-build/requirements.txt


### PR DESCRIPTION
This PR fixes broken release builds for macOS and Windows in GitHub Actions.

macOS:
- Migrated macOS release build to an Intel-based runner (x86_64), matching historical macOS artifacts.
- Explicitly force x86_64 toolchain and linker flags to avoid accidental ARM64 builds.
- Fixed zbar build failures by ensuring proper iconv linkage on modern macOS runners.
- Updated workflow to use supported macOS runner images after macos-13 retirement.

Windows:
- Updated Wine-based build environment to a supported version.
- Restored successful Windows installer generation.

Notes:
- Verified that historical macOS DMG artifacts are Intel-only (x86_64).
- Apple Silicon users continue to run macOS builds via Rosetta, preserving backward compatibility.
- No functional changes to application code; CI/build system only.

This restores fully green release builds across macOS and Windows.
