### PR TITLE
Fix testnet block explorer URL

### DIFF
--- a/electrum_dash/util.py
+++ b/electrum_dash/util.py
@@ -801,7 +801,7 @@ mainnet_block_explorers = {
 }
 
 testnet_block_explorers = {
-    'Dash.org': ('https://testnet-insight.dashevo.org/insight/',
+    'Dash.org': ('https://insight.testnet.networks.dash.org/insight/',
                  {'tx': 'tx/', 'addr': 'address/'}),
     'system default': ('blockchain:/',
                        {'tx': 'tx/', 'addr': 'address/'}),


### PR DESCRIPTION
Replaced outdated testnet block explorer entry with the official Dash.org Insight endpoint.

This ensures that transaction and address links on testnet point to the correct, maintained Dash infrastructure instead of a deprecated or third-party explorer.

No functional logic changes - URL mapping only.